### PR TITLE
[Be] 유저 단일 조회, 프로필이미지, 자기소개 포함한 회원가입, 커스텀 예외 구현

### DIFF
--- a/backend/src/main/java/com/healthy_plate/auth/application/AuthService.java
+++ b/backend/src/main/java/com/healthy_plate/auth/application/AuthService.java
@@ -36,6 +36,11 @@ public class AuthService {
         User user = userRepository.findById(refreshToken.getUserId())
             .orElseThrow(() -> new CustomAuthenticationException(BusinessErrorCode.USER_NOT_FOUND));
 
+        // 프로필 미등록 사용자 차단
+        if (user.isFirstLogin()) {
+            throw new CustomAuthenticationException(AuthenticationErrorCode.PROFILE_REGISTRATION_REQUIRED);
+        }
+
         return jwtTokenProvider.generateAccessToken(
             user.getId(),
             user.getEmail().getValue(),

--- a/backend/src/main/java/com/healthy_plate/auth/application/AuthService.java
+++ b/backend/src/main/java/com/healthy_plate/auth/application/AuthService.java
@@ -75,6 +75,7 @@ public class AuthService {
         }
 
         user.updateNickname(nickname);
+        userRepository.save(user);
 
         return jwtTokenProvider.generateAccessToken(
             user.getId(),

--- a/backend/src/main/java/com/healthy_plate/auth/infrastructure/config/SecurityConfig.java
+++ b/backend/src/main/java/com/healthy_plate/auth/infrastructure/config/SecurityConfig.java
@@ -42,7 +42,8 @@ public class SecurityConfig {
                     "/v3/api-docs/**",
                     "/swagger-resources/**",
                     "/oauth2/**",
-                    "/api/auth/**"
+                    "/api/auth/**",
+                    "/api/users/duplicate/**"
                 ).permitAll()
                 .anyRequest().authenticated()
             )

--- a/backend/src/main/java/com/healthy_plate/auth/presentation/dto/UpdateNicknameRequest.java
+++ b/backend/src/main/java/com/healthy_plate/auth/presentation/dto/UpdateNicknameRequest.java
@@ -6,6 +6,10 @@ import jakarta.validation.constraints.Size;
 public record UpdateNicknameRequest(
     @NotBlank(message = "닉네임은 필수입니다.")
     @Size(min = 2, max = 50, message = "닉네임은 2-50자 사이여야 합니다.")
-    String nickname
+    String nickname,
+    String profileImageUrl,
+    @Size(max = 500, message = "자기소개는 최대 500자까지 입력할 수 있습니다.")
+    String introduction
 ) {
+
 }

--- a/backend/src/main/java/com/healthy_plate/shared/error/exception/AuthenticationErrorCode.java
+++ b/backend/src/main/java/com/healthy_plate/shared/error/exception/AuthenticationErrorCode.java
@@ -11,7 +11,8 @@ public enum AuthenticationErrorCode implements ErrorCode {
     ALREADY_REGISTERED_NICKNAME("A105", "이미 등록된 사용자입니다", HttpStatus.BAD_REQUEST),
     OAUTH2_LOGIN_FAILED("A106", "소셜 로그인에 실패했습니다", HttpStatus.UNAUTHORIZED),
     EXPIRED_ACCESS_TOKEN("A107", "만료된 Access Token 입니다.", HttpStatus.UNAUTHORIZED),
-    INVALID_ACCESS_TOKEN("A108", "유효하지 않은 Access Token 입니다.", HttpStatus.UNAUTHORIZED);
+    INVALID_ACCESS_TOKEN("A108", "유효하지 않은 Access Token 입니다.", HttpStatus.UNAUTHORIZED),
+    PROFILE_REGISTRATION_REQUIRED("A109", "프로필 등록이 필요합니다", HttpStatus.FORBIDDEN);
 
     private final String code;
     private final String message;

--- a/backend/src/main/java/com/healthy_plate/user/domain/model/UserProfile.java
+++ b/backend/src/main/java/com/healthy_plate/user/domain/model/UserProfile.java
@@ -17,12 +17,17 @@ public class UserProfile {
     @Column(name = "profile_image_url")
     private String profileImageUrl;
 
-    public static UserProfile of(String nickname, String profileImageUrl) {
-        validateName(nickname);
+    @Column(length = 500)
+    private String introduction;
 
+
+    public static UserProfile of(String nickname, String profileImageUrl, String introduction) {
+        validateName(nickname);
+        validateIntroduction(introduction);
         UserProfile profile = new UserProfile();
         profile.nickname = nickname.trim();
         profile.profileImageUrl = profileImageUrl;
+        profile.introduction = introduction;
         return profile;
     }
 
@@ -30,6 +35,7 @@ public class UserProfile {
         UserProfile profile = new UserProfile();
         profile.nickname = null;
         profile.profileImageUrl = null;
+        profile.introduction = null;
         return profile;
     }
 
@@ -48,6 +54,14 @@ public class UserProfile {
         }
         if (name.length() < 2 || name.length() > 50) {
             throw new IllegalArgumentException("이름은 2-50자 사이여야 합니다.");
+        }
+    }
+
+    private static void validateIntroduction(String introduction) {
+        if (introduction != null) {
+            if (introduction.length() > 500) {
+                throw new IllegalArgumentException("자기소개는 500자 미만이어야 합니다.");
+            }
         }
     }
 }

--- a/backend/src/test/java/com/healthy_plate/user/domain/UserProfileTest.java
+++ b/backend/src/test/java/com/healthy_plate/user/domain/UserProfileTest.java
@@ -14,14 +14,15 @@ import org.junit.jupiter.params.provider.ValueSource;
 class UserProfileTest {
 
     @Test
-    @DisplayName("유효한 닉네임과 프로필 이미지 URL로 UserProfile 객체를 생성한다")
+    @DisplayName("유효한 닉네임과 프로필 이미지 URL, 자기소개로 UserProfile 객체를 생성한다")
     void createUserProfileWithValidValues() {
         // given
         String nickname = "테스트유저";
         String profileImageUrl = "https://example.com/profile.jpg";
+        String introduction = "안녕하세요 취미로 요리하는 사람입니다.";
 
         // when
-        UserProfile profile = UserProfile.of(nickname, profileImageUrl);
+        UserProfile profile = UserProfile.of(nickname, profileImageUrl, introduction);
 
         // then
         assertThat(profile.getNickname()).isEqualTo("테스트유저");
@@ -33,13 +34,28 @@ class UserProfileTest {
     void createUserProfileWithoutProfileImage() {
         // given
         String nickname = "테스트유저";
+        String introduction = "안녕하세요 취미로 요리하는 사람입니다.";
 
         // when
-        UserProfile profile = UserProfile.of(nickname, null);
+        UserProfile profile = UserProfile.of(nickname, null, introduction);
 
         // then
         assertThat(profile.getNickname()).isEqualTo("테스트유저");
         assertThat(profile.getProfileImageUrl()).isNull();
+    }
+
+    @Test
+    @DisplayName("자기소개 없이 UserProfile 객체를 생성한다")
+    void createUserProfileWithoutIntroduction() {
+        // given
+        String nickname = "테스트유저";
+        String profileImageUrl = "https://example.com/profile.jpg";
+
+        // when
+        UserProfile profile = UserProfile.of(nickname, profileImageUrl, null);
+
+        // then
+        assertThat(profile.getNickname()).isEqualTo("테스트유저");
     }
 
     @Test
@@ -49,7 +65,7 @@ class UserProfileTest {
         String nicknameWithSpaces = "  테스트유저  ";
 
         // when
-        UserProfile profile = UserProfile.of(nicknameWithSpaces, null);
+        UserProfile profile = UserProfile.of(nicknameWithSpaces, null, null);
 
         // then
         assertThat(profile.getNickname()).isEqualTo("테스트유저");
@@ -61,7 +77,7 @@ class UserProfileTest {
     @DisplayName("닉네임이 null이거나 공백이면 예외가 발생한다")
     void throwExceptionWhenNicknameIsNullOrBlank(String invalidNickname) {
         // when & then
-        assertThatThrownBy(() -> UserProfile.of(invalidNickname, null))
+        assertThatThrownBy(() -> UserProfile.of(invalidNickname, null, null))
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessage("이름은 필수입니다.");
     }
@@ -73,7 +89,7 @@ class UserProfileTest {
         String shortNickname = "a";
 
         // when & then
-        assertThatThrownBy(() -> UserProfile.of(shortNickname, null))
+        assertThatThrownBy(() -> UserProfile.of(shortNickname, null, null))
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessage("이름은 2-50자 사이여야 합니다.");
     }
@@ -85,7 +101,7 @@ class UserProfileTest {
         String longNickname = "a".repeat(51);
 
         // when & then
-        assertThatThrownBy(() -> UserProfile.of(longNickname, null))
+        assertThatThrownBy(() -> UserProfile.of(longNickname, null, null))
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessage("이름은 2-50자 사이여야 합니다.");
     }
@@ -97,7 +113,7 @@ class UserProfileTest {
         String minimumNickname = "ab";
 
         // when
-        UserProfile profile = UserProfile.of(minimumNickname, null);
+        UserProfile profile = UserProfile.of(minimumNickname, null, null);
 
         // then
         assertThat(profile.getNickname()).isEqualTo("ab");
@@ -110,9 +126,24 @@ class UserProfileTest {
         String maximumNickname = "a".repeat(50);
 
         // when
-        UserProfile profile = UserProfile.of(maximumNickname, null);
+        UserProfile profile = UserProfile.of(maximumNickname, null, null);
 
         // then
         assertThat(profile.getNickname()).hasSize(50);
     }
+
+    @Test
+    @DisplayName("자기소개가 500자가 넘을 시 예외가 발생한다.")
+    void throwExceptionWhenIntroductionTooLong() {
+        // given
+        String nickName = "chef";
+        String maximumIntroduction = "a".repeat(501);
+
+        // when & then
+        assertThatThrownBy(() -> UserProfile.of(nickName, null, maximumIntroduction))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("자기소개는 500자 미만이어야 합니다.");
+    }
+
+
 }

--- a/backend/src/test/java/com/healthy_plate/user/domain/UserTest.java
+++ b/backend/src/test/java/com/healthy_plate/user/domain/UserTest.java
@@ -18,7 +18,7 @@ class UserTest {
     void createUserWithValidValues() {
         // given
         Email email = Email.of("test@example.com");
-        UserProfile profile = UserProfile.of("테스트유저", "https://example.com/profile.jpg");
+        UserProfile profile = UserProfile.of("테스트유저", "https://example.com/profile.jpg", "안녕하세요 꿈나무입니다.");
         OAuth2Provider provider = OAuth2Provider.GOOGLE;
         String providerId = "google-123456";
         UserRole role = UserRole.ROLE_USER;
@@ -39,7 +39,7 @@ class UserTest {
     void createUserWithGoogleProvider() {
         // given
         Email email = Email.of("google@example.com");
-        UserProfile profile = UserProfile.of("구글유저", null);
+        UserProfile profile = UserProfile.of("구글유저", null, "안녕하세요 꿈나무입니다.");
         OAuth2Provider provider = OAuth2Provider.GOOGLE;
         String providerId = "google-123";
 
@@ -56,7 +56,7 @@ class UserTest {
     void createUserWithKakaoProvider() {
         // given
         Email email = Email.of("kakao@example.com");
-        UserProfile profile = UserProfile.of("카카오유저", null);
+        UserProfile profile = UserProfile.of("카카오유저", null, "안녕하세요 꿈나무입니다.");
         OAuth2Provider provider = OAuth2Provider.KAKAO;
         String providerId = "kakao-456";
 
@@ -73,7 +73,7 @@ class UserTest {
     void createUserWithNaverProvider() {
         // given
         Email email = Email.of("naver@example.com");
-        UserProfile profile = UserProfile.of("네이버유저", null);
+        UserProfile profile = UserProfile.of("네이버유저", null, "안녕하세요 꿈나무입니다.");
         OAuth2Provider provider = OAuth2Provider.NAVER;
         String providerId = "naver-789";
 
@@ -90,7 +90,7 @@ class UserTest {
     void createUserWithAdminRole() {
         // given
         Email email = Email.of("admin@example.com");
-        UserProfile profile = UserProfile.of("관리자", null);
+        UserProfile profile = UserProfile.of("관리자", null, "안녕하세요 꿈나무입니다.");
 
         // when
         User user = new User(email, profile, OAuth2Provider.GOOGLE, "admin-123", UserRole.ROLE_ADMIN);


### PR DESCRIPTION
### 🧪 작업 브랜치
> [현재 작업한 브랜치명]

<br/>

---
### 🔗 연결된 이슈 번호
<!--이 PR이 머지될 때 자동으로 닫힐 이슈들을 기재합니다.
자동 닫힘 키워드를 사용해주세요: **`#이슈번호`** -->

- #32 
- #29

 <br/>

### 🛠 상세 작업 내용
---
<!--작업 내용을 구체적인 목록 형태로 기술합니다.-->
- [ ] 작업 내용 1: 유저 단일 조회 api 구현
- [ ] 작업 내용 2: 회원가입시 프로필이미지, 자기소개 포함하도록 수정
- [ ] 작업 내용 3: 유저, 인증 관련 커스텀 예외 적용
<br/>

### 📷 스크린샷 (선택사항)
---
<!-- UI 변경이나 특정 동작이 필요한 경우 스크린샷이나 GIF를 첨부합니다.-->
