### PR TITLE
[BE] 카카오 , 네이버 소셜로그인 구현

### DIFF
--- a/backend/src/main/java/com/healthy_plate/auth/infrastructure/oauth2/GoogleOAuth2UserInfo.java
+++ b/backend/src/main/java/com/healthy_plate/auth/infrastructure/oauth2/GoogleOAuth2UserInfo.java
@@ -27,8 +27,4 @@ public class GoogleOAuth2UserInfo implements OAuth2UserInfo {
         return attributes.get("email").toString();
     }
 
-    @Override
-    public String getName() {
-        return attributes.get("name").toString();
-    }
 }

--- a/backend/src/main/java/com/healthy_plate/auth/infrastructure/oauth2/KakaoOAuth2UserInfo.java
+++ b/backend/src/main/java/com/healthy_plate/auth/infrastructure/oauth2/KakaoOAuth2UserInfo.java
@@ -11,7 +11,11 @@ public class KakaoOAuth2UserInfo implements OAuth2UserInfo {
 
     public KakaoOAuth2UserInfo(Map<String, Object> attributes) {
         this.attributes = attributes;
-        this.kakaoAccount = extractMap(attributes.get("kakao_account"));
+        Object kakaoAccountObj = attributes.get("kakao_account");
+        if (kakaoAccountObj == null) {
+            throw new IllegalArgumentException("Kakao account object is missing in Kakao OAuth2 attributes");
+        }
+        this.kakaoAccount = extractMap(kakaoAccountObj);
     }
 
     @Override
@@ -21,12 +25,20 @@ public class KakaoOAuth2UserInfo implements OAuth2UserInfo {
 
     @Override
     public String getProviderId() {
-        return attributes.get("id").toString();
+        Object id = attributes.get("id");
+        if (id == null) {
+            throw new IllegalArgumentException("Provider ID is missing in Kakao OAuth2 response");
+        }
+        return id.toString();
     }
 
     @Override
     public String getEmail() {
-        return kakaoAccount.get("email").toString();
+        Object email = kakaoAccount.get("email");
+        if (email == null) {
+            throw new IllegalArgumentException("Email is missing in Kakao OAuth2 response");
+        }
+        return email.toString();
     }
 
     @SuppressWarnings("unchecked")
@@ -34,7 +46,7 @@ public class KakaoOAuth2UserInfo implements OAuth2UserInfo {
         if (obj instanceof Map) {
             return (Map<String, Object>) obj;
         } else {
-            throw new IllegalArgumentException("Invalid " + "kakao_account" + " structure in OAuth2 response");
+            throw new IllegalArgumentException("Invalid kakao_account structure in Kakao OAuth2 response");
         }
     }
 }

--- a/backend/src/main/java/com/healthy_plate/auth/infrastructure/oauth2/KakaoOAuth2UserInfo.java
+++ b/backend/src/main/java/com/healthy_plate/auth/infrastructure/oauth2/KakaoOAuth2UserInfo.java
@@ -1,0 +1,46 @@
+package com.healthy_plate.auth.infrastructure.oauth2;
+
+import java.util.Map;
+
+public class KakaoOAuth2UserInfo implements OAuth2UserInfo {
+
+    private static final String PROVIDER = "kakao";
+
+    private final Map<String, Object> attributes;
+    private final Map<String, Object> kakaoAccount;
+
+    public KakaoOAuth2UserInfo(Map<String, Object> attributes) {
+        this.attributes = attributes;
+        this.kakaoAccount = extractMap(attributes.get("kakao_account"), "kakao_account");
+    }
+
+    @Override
+    public String getProvider() {
+        return PROVIDER;
+    }
+
+    @Override
+    public String getProviderId() {
+        return attributes.get("id").toString();
+    }
+
+    @Override
+    public String getEmail() {
+        return kakaoAccount.get("email").toString();
+    }
+
+    @Override
+    public String getName() {
+        Map<String, Object> profile = extractMap(kakaoAccount.get("profile"), "profile");
+        return profile.get("nickname").toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> extractMap(Object obj, String fieldName) {
+        if (obj instanceof Map) {
+            return (Map<String, Object>) obj;
+        } else {
+            throw new IllegalArgumentException("Invalid " + fieldName + " structure in OAuth2 response");
+        }
+    }
+}

--- a/backend/src/main/java/com/healthy_plate/auth/infrastructure/oauth2/KakaoOAuth2UserInfo.java
+++ b/backend/src/main/java/com/healthy_plate/auth/infrastructure/oauth2/KakaoOAuth2UserInfo.java
@@ -11,7 +11,7 @@ public class KakaoOAuth2UserInfo implements OAuth2UserInfo {
 
     public KakaoOAuth2UserInfo(Map<String, Object> attributes) {
         this.attributes = attributes;
-        this.kakaoAccount = extractMap(attributes.get("kakao_account"), "kakao_account");
+        this.kakaoAccount = extractMap(attributes.get("kakao_account"));
     }
 
     @Override
@@ -29,18 +29,12 @@ public class KakaoOAuth2UserInfo implements OAuth2UserInfo {
         return kakaoAccount.get("email").toString();
     }
 
-    @Override
-    public String getName() {
-        Map<String, Object> profile = extractMap(kakaoAccount.get("profile"), "profile");
-        return profile.get("nickname").toString();
-    }
-
     @SuppressWarnings("unchecked")
-    private Map<String, Object> extractMap(Object obj, String fieldName) {
+    private Map<String, Object> extractMap(Object obj) {
         if (obj instanceof Map) {
             return (Map<String, Object>) obj;
         } else {
-            throw new IllegalArgumentException("Invalid " + fieldName + " structure in OAuth2 response");
+            throw new IllegalArgumentException("Invalid " + "kakao_account" + " structure in OAuth2 response");
         }
     }
 }

--- a/backend/src/main/java/com/healthy_plate/auth/infrastructure/oauth2/NaverOAuth2UserInfo.java
+++ b/backend/src/main/java/com/healthy_plate/auth/infrastructure/oauth2/NaverOAuth2UserInfo.java
@@ -9,7 +9,11 @@ public class NaverOAuth2UserInfo implements OAuth2UserInfo{
     private final Map<String, Object> response;
 
     public NaverOAuth2UserInfo(Map<String, Object> attributes) {
-        this.response = extractMap(attributes.get("response"));
+        Object responseObj = attributes.get("response");
+        if (responseObj == null) {
+            throw new IllegalArgumentException("Response object is missing in Naver OAuth2 attributes");
+        }
+        this.response = extractMap(responseObj);
     }
 
     @Override
@@ -19,12 +23,20 @@ public class NaverOAuth2UserInfo implements OAuth2UserInfo{
 
     @Override
     public String getProviderId() {
-        return response.get("id").toString();
+        Object id = response.get("id");
+        if (id == null) {
+            throw new IllegalArgumentException("Provider ID is missing in Naver OAuth2 response");
+        }
+        return id.toString();
     }
 
     @Override
     public String getEmail() {
-        return response.get("email").toString();
+        Object email = response.get("email");
+        if (email == null) {
+            throw new IllegalArgumentException("Email is missing in Naver OAuth2 response");
+        }
+        return email.toString();
     }
 
     @SuppressWarnings("unchecked")
@@ -32,7 +44,7 @@ public class NaverOAuth2UserInfo implements OAuth2UserInfo{
         if (obj instanceof Map) {
             return (Map<String, Object>) obj;
         } else {
-            throw new IllegalArgumentException("Invalid " + "response" + " structure in OAuth2 response");
+            throw new IllegalArgumentException("Invalid response structure in Naver OAuth2 response");
         }
     }
 }

--- a/backend/src/main/java/com/healthy_plate/auth/infrastructure/oauth2/NaverOAuth2UserInfo.java
+++ b/backend/src/main/java/com/healthy_plate/auth/infrastructure/oauth2/NaverOAuth2UserInfo.java
@@ -1,0 +1,38 @@
+package com.healthy_plate.auth.infrastructure.oauth2;
+
+import java.util.Map;
+
+public class NaverOAuth2UserInfo implements OAuth2UserInfo{
+
+    private static final String PROVIDER = "naver";
+
+    private final Map<String, Object> response;
+
+    public NaverOAuth2UserInfo(Map<String, Object> attributes) {
+        this.response = extractMap(attributes.get("response"));
+    }
+
+    @Override
+    public String getProvider() {
+        return PROVIDER;
+    }
+
+    @Override
+    public String getProviderId() {
+        return response.get("id").toString();
+    }
+
+    @Override
+    public String getEmail() {
+        return response.get("email").toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> extractMap(Object obj) {
+        if (obj instanceof Map) {
+            return (Map<String, Object>) obj;
+        } else {
+            throw new IllegalArgumentException("Invalid " + "response" + " structure in OAuth2 response");
+        }
+    }
+}

--- a/backend/src/main/java/com/healthy_plate/auth/infrastructure/oauth2/OAuth2UserInfo.java
+++ b/backend/src/main/java/com/healthy_plate/auth/infrastructure/oauth2/OAuth2UserInfo.java
@@ -8,5 +8,4 @@ public interface OAuth2UserInfo {
 
     String getEmail();
 
-    String getName();
 }

--- a/backend/src/main/java/com/healthy_plate/auth/infrastructure/oauth2/OAuth2UserInfoFactory.java
+++ b/backend/src/main/java/com/healthy_plate/auth/infrastructure/oauth2/OAuth2UserInfoFactory.java
@@ -8,7 +8,8 @@ public class OAuth2UserInfoFactory {
     public static OAuth2UserInfo getOAuth2UserInfo(OAuth2Provider provider, Map<String, Object> attributes) {
         return switch (provider) {
             case GOOGLE -> new GoogleOAuth2UserInfo(attributes);
-            case KAKAO, NAVER -> throw new IllegalArgumentException("미설정 Oauth 입니다.");
+            case KAKAO -> new KakaoOAuth2UserInfo(attributes);
+            case NAVER -> throw new IllegalArgumentException("미설정 Oauth 입니다.");
         };
     }
 }

--- a/backend/src/main/java/com/healthy_plate/auth/infrastructure/oauth2/OAuth2UserInfoFactory.java
+++ b/backend/src/main/java/com/healthy_plate/auth/infrastructure/oauth2/OAuth2UserInfoFactory.java
@@ -9,7 +9,7 @@ public class OAuth2UserInfoFactory {
         return switch (provider) {
             case GOOGLE -> new GoogleOAuth2UserInfo(attributes);
             case KAKAO -> new KakaoOAuth2UserInfo(attributes);
-            case NAVER -> throw new IllegalArgumentException("미설정 Oauth 입니다.");
+            case NAVER -> new NaverOAuth2UserInfo(attributes);
         };
     }
 }

--- a/backend/src/main/java/com/healthy_plate/user/domain/model/Email.java
+++ b/backend/src/main/java/com/healthy_plate/user/domain/model/Email.java
@@ -13,7 +13,7 @@ public class Email {
 
     private static final String EMAIL_PATTERN = "^[A-Za-z0-9+_.-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$";
 
-    @Column(name = "email", nullable = false, unique = true)
+    @Column(name = "email", nullable = false)
     private String value;
 
 

--- a/backend/src/main/java/com/healthy_plate/user/domain/model/User.java
+++ b/backend/src/main/java/com/healthy_plate/user/domain/model/User.java
@@ -11,12 +11,16 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name = "users")
+@Table(
+    name = "users",
+    uniqueConstraints = @UniqueConstraint(columnNames = {"provider", "provider_id"})
+)
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class User extends BaseEntity {


### PR DESCRIPTION
### 🧪 작업 브랜치
> be/kakao-naver-login

<br/>

---
### 🔗 연결된 이슈 번호
<!--이 PR이 머지될 때 자동으로 닫힐 이슈들을 기재합니다.
자동 닫힘 키워드를 사용해주세요: **`#이슈번호`** -->

- #40 
- #41 
<br/>

### 🛠 상세 작업 내용
---
<!--작업 내용을 구체적인 목록 형태로 기술합니다.-->
- [ ] 작업 내용 1: 네이버와 카카오 소셜로그인을 구현했습니다. 각 provider 사에 맞게 OAuthUserInfo 인터페이스를 구현한 클래스에 provider, proivderId, email 정보를 가져올 수 있도록 알맞은 attribute를 가져와 처리했습니다.

<br/>

### 📷 스크린샷 (선택사항)
---
<!-- UI 변경이나 특정 동작이 필요한 경우 스크린샷이나 GIF를 첨부합니다.-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * Kakao를 통한 소셜 로그인 추가
  * Naver를 통한 소셜 로그인 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->