### PR TITLE
[Be] 유저 회원가입시 Token 전략 수정 

### DIFF
--- a/backend/src/main/java/com/healthy_plate/auth/application/AuthService.java
+++ b/backend/src/main/java/com/healthy_plate/auth/application/AuthService.java
@@ -90,11 +90,14 @@ public class AuthService {
 
     @Transactional
     public void registerUserInfo(
-        final User user,
+        final Long userId,
         final String nickname,
         final String profileImageUrl,
         final String introduction
     ) {
+        final User user = userRepository.findById(userId)
+            .orElseThrow(() -> new CustomAuthenticationException(BusinessErrorCode.USER_NOT_FOUND));
+
         user.updateProfile(nickname, profileImageUrl, introduction);
         userRepository.save(user);
     }

--- a/backend/src/main/java/com/healthy_plate/auth/domain/model/JwtTokenProvider.java
+++ b/backend/src/main/java/com/healthy_plate/auth/domain/model/JwtTokenProvider.java
@@ -69,7 +69,8 @@ public class JwtTokenProvider {
             .parseSignedClaims(token)
             .getPayload();
 
-        return UserRole.valueOf(claims.get("role", String.class));
+        String roleString = claims.get("role", String.class);
+        return roleString != null ? UserRole.valueOf(roleString) : null;
     }
 
     public boolean validateToken(String token) {

--- a/backend/src/main/java/com/healthy_plate/auth/domain/service/RefreshTokenService.java
+++ b/backend/src/main/java/com/healthy_plate/auth/domain/service/RefreshTokenService.java
@@ -3,6 +3,7 @@ package com.healthy_plate.auth.domain.service;
 import com.healthy_plate.auth.domain.model.RefreshToken;
 import com.healthy_plate.auth.domain.repository.RefreshTokenRepository;
 import java.time.LocalDateTime;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,14 +16,15 @@ public class RefreshTokenService {
 
     @Transactional
     public void saveRefreshToken(final Long userId, final String token, long refreshTokenExpiration) {
-        refreshTokenRepository.findByUserId(userId)
-            .ifPresent(existing -> {
-                if (!existing.isExpired()) {
-                    return;
-                }
-                refreshTokenRepository.deleteByToken(existing.getToken());
+        Optional<RefreshToken> existing = refreshTokenRepository.findByUserId(userId);
 
-            });
+        if (existing.isPresent() && !existing.get().isExpired()) {
+            // 유효한 토큰이 있으면 새로 저장하지 않음
+            return;
+        }
+
+        // 만료된 토큰 삭제
+        existing.ifPresent(old -> refreshTokenRepository.deleteByToken(old.getToken()));
 
         final LocalDateTime expiryDate = LocalDateTime.now().plusSeconds(refreshTokenExpiration / 1000);
         final RefreshToken refreshToken = new RefreshToken(token, userId, expiryDate);

--- a/backend/src/main/java/com/healthy_plate/auth/domain/service/RefreshTokenService.java
+++ b/backend/src/main/java/com/healthy_plate/auth/domain/service/RefreshTokenService.java
@@ -15,19 +15,21 @@ public class RefreshTokenService {
     private final RefreshTokenRepository refreshTokenRepository;
 
     @Transactional
-    public void saveRefreshToken(final Long userId, final String token, long refreshTokenExpiration) {
-        Optional<RefreshToken> existing = refreshTokenRepository.findByUserId(userId);
+    public String saveRefreshToken(final Long userId, final String token, long refreshTokenExpiration) {
+        Optional<RefreshToken> existedToken = refreshTokenRepository.findByUserId(userId);
 
-        if (existing.isPresent() && !existing.get().isExpired()) {
+        if (existedToken.isPresent() && !existedToken.get().isExpired()) {
             // 유효한 토큰이 있으면 새로 저장하지 않음
-            return;
+            return existedToken.get().getToken();
         }
 
         // 만료된 토큰 삭제
-        existing.ifPresent(old -> refreshTokenRepository.deleteByToken(old.getToken()));
+        existedToken.ifPresent(old -> refreshTokenRepository.deleteByToken(old.getToken()));
 
         final LocalDateTime expiryDate = LocalDateTime.now().plusSeconds(refreshTokenExpiration / 1000);
         final RefreshToken refreshToken = new RefreshToken(token, userId, expiryDate);
         refreshTokenRepository.save(refreshToken);
+
+        return token;
     }
 }

--- a/backend/src/main/java/com/healthy_plate/auth/infrastructure/oauth2/OAuth2LoginSuccessHandler.java
+++ b/backend/src/main/java/com/healthy_plate/auth/infrastructure/oauth2/OAuth2LoginSuccessHandler.java
@@ -52,9 +52,9 @@ public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHan
 
         updateUserLastLogin(user);
 
-        final String refreshToken = jwtTokenProvider.generateRefreshToken(oauth2User.getUserId());
+        final String newRefreshToken = jwtTokenProvider.generateRefreshToken(oauth2User.getUserId());
 
-        refreshTokenService.saveRefreshToken(oauth2User.getUserId(), refreshToken, jwtProperties.refreshTokenExpiration());
+        String refreshToken = refreshTokenService.saveRefreshToken(oauth2User.getUserId(), newRefreshToken, jwtProperties.refreshTokenExpiration());
         addRefreshTokenCookies(response, refreshToken);
 
         final String redirectUrl = UriComponentsBuilder.fromUriString(targetUrl)

--- a/backend/src/main/java/com/healthy_plate/auth/infrastructure/util/CookieUtil.java
+++ b/backend/src/main/java/com/healthy_plate/auth/infrastructure/util/CookieUtil.java
@@ -21,6 +21,9 @@ public class CookieUtil {
     }
 
     public static String findRefreshTokenWithCookie(final Cookie[] cookies) {
+        if (cookies == null) {
+            throw new IllegalArgumentException("Cookie를 찾을 수 없습니다.");
+        }
         return Arrays.stream(cookies)
             .filter(cookie -> cookie.getName().equals(REFRESH_TOKEN_NAME))
             .findFirst()

--- a/backend/src/main/java/com/healthy_plate/auth/presentation/AuthController.java
+++ b/backend/src/main/java/com/healthy_plate/auth/presentation/AuthController.java
@@ -79,10 +79,10 @@ public class AuthController implements SwaggerAuthController {
     @PatchMapping("/register")
     public ResponseEntity<Void> registerUserInfo(
         @Valid @RequestBody final RegisterUserProfileRequest request,
-        @AuthenticationPrincipal final User user
+        @AuthenticationPrincipal final Long userId
     ) {
         authService.registerUserInfo(
-            user,
+            userId,
             request.nickname(),
             request.profileImageUrl(),
             request.introduction()

--- a/backend/src/main/java/com/healthy_plate/auth/presentation/AuthController.java
+++ b/backend/src/main/java/com/healthy_plate/auth/presentation/AuthController.java
@@ -38,6 +38,16 @@ public class AuthController implements SwaggerAuthController {
     @Value("${app.cookie.secure}")
     private boolean cookieSecure;
 
+    @PostMapping("/onboarding")
+    public ResponseEntity<TokenResponse> onBoardingAccessToken(
+        final HttpServletRequest request
+    ) {
+        final String refreshToken = CookieUtil.findRefreshTokenWithCookie(request.getCookies());
+        final String newAccessToken = authService.generateAccessToken(refreshToken);
+
+        return ResponseEntity.ok(new TokenResponse(newAccessToken));
+    }
+
     @PostMapping("/token")
     public ResponseEntity<TokenResponse> getAccessToken(
         final HttpServletRequest request

--- a/backend/src/main/java/com/healthy_plate/auth/presentation/AuthController.java
+++ b/backend/src/main/java/com/healthy_plate/auth/presentation/AuthController.java
@@ -17,6 +17,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -43,7 +44,7 @@ public class AuthController implements SwaggerAuthController {
         final HttpServletRequest request
     ) {
         final String refreshToken = CookieUtil.findRefreshTokenWithCookie(request.getCookies());
-        final String newAccessToken = authService.generateAccessToken(refreshToken);
+        final String newAccessToken = authService.generateOnboardingAccessToken(refreshToken);
 
         return ResponseEntity.ok(new TokenResponse(newAccessToken));
     }
@@ -76,19 +77,18 @@ public class AuthController implements SwaggerAuthController {
     }
 
     @PatchMapping("/register")
-    public ResponseEntity<TokenResponse> registerUserInfo(
+    public ResponseEntity<Void> registerUserInfo(
         @Valid @RequestBody final RegisterUserProfileRequest request,
-        final HttpServletRequest httpRequest
+        @AuthenticationPrincipal final User user
     ) {
-        final String refreshToken = CookieUtil.findRefreshTokenWithCookie(httpRequest.getCookies());
-        final String accessToken = authService.registerUserInfo(
-            refreshToken,
+        authService.registerUserInfo(
+            user,
             request.nickname(),
             request.profileImageUrl(),
             request.introduction()
         );
 
-        return ResponseEntity.ok(new TokenResponse(accessToken));
+        return ResponseEntity.ok().build();
     }
 
     @PostMapping("/logout")

--- a/backend/src/main/java/com/healthy_plate/auth/presentation/SwaggerAuthController.java
+++ b/backend/src/main/java/com/healthy_plate/auth/presentation/SwaggerAuthController.java
@@ -12,8 +12,10 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.RequestBody;
 
 @Tag(name = "인증", description = "인증 관련 API")
 public interface SwaggerAuthController {
@@ -31,15 +33,29 @@ public interface SwaggerAuthController {
                 )
             ),
             @ApiResponse(
-                responseCode = "401",
-                description = "유효하지 않은 리프레시 토큰",
+                responseCode = "400",
+                description = "잘못된 요청 (refresh_token 쿠키 없음)",
                 content = @Content(
                     schema = @Schema(implementation = ErrorResponse.class)
                 )
             ),
             @ApiResponse(
-                responseCode = "400",
-                description = "잘못된 요청",
+                responseCode = "401",
+                description = "유효하지 않거나 만료된 리프레시 토큰",
+                content = @Content(
+                    schema = @Schema(implementation = ErrorResponse.class)
+                )
+            ),
+            @ApiResponse(
+                responseCode = "403",
+                description = "프로필 등록이 필요합니다",
+                content = @Content(
+                    schema = @Schema(implementation = ErrorResponse.class)
+                )
+            ),
+            @ApiResponse(
+                responseCode = "404",
+                description = "사용자를 찾을 수 없습니다",
                 content = @Content(
                     schema = @Schema(implementation = ErrorResponse.class)
                 )
@@ -79,21 +95,28 @@ public interface SwaggerAuthController {
         responses = {
             @ApiResponse(
                 responseCode = "200",
-                description = "Presigned URL 생성 성공",
+                description = "PreSigned URL 생성 성공",
                 content = @Content(
                     schema = @Schema(implementation = PresignedUrlResponse.class)
                 )
             ),
             @ApiResponse(
                 responseCode = "400",
-                description = "잘못된 요청 (지원하지 않는 파일 형식, 파일 크기 초과, contentType/fileSize 누락 등)",
+                description = "잘못된 요청 (refresh_token 쿠키 없음, 지원하지 않는 파일 형식, 파일 크기 초과, 유효성 검증 실패)",
                 content = @Content(
                     schema = @Schema(implementation = ErrorResponse.class)
                 )
             ),
             @ApiResponse(
                 responseCode = "401",
-                description = "유효하지 않은 리프레시 토큰",
+                description = "유효하지 않거나 만료된 리프레시 토큰",
+                content = @Content(
+                    schema = @Schema(implementation = ErrorResponse.class)
+                )
+            ),
+            @ApiResponse(
+                responseCode = "404",
+                description = "사용자를 찾을 수 없습니다",
                 content = @Content(
                     schema = @Schema(implementation = ErrorResponse.class)
                 )
@@ -101,8 +124,8 @@ public interface SwaggerAuthController {
         }
     )
     ResponseEntity<PresignedUrlResponse> getPresignedUrl(
-        PresignedUrlRequest request,
-        HttpServletRequest httpRequest
+            @Valid @RequestBody PresignedUrlRequest request,
+            HttpServletRequest httpRequest
     );
 
     @Operation(
@@ -131,14 +154,21 @@ public interface SwaggerAuthController {
             ),
             @ApiResponse(
                 responseCode = "400",
-                description = "잘못된 요청 (유효성 검증 실패, 파일 형식 오류, 파일 크기 초과 등)",
+                description = "잘못된 요청 (refresh_token 쿠키 없음, 유효성 검증 실패)",
                 content = @Content(
                     schema = @Schema(implementation = ErrorResponse.class)
                 )
             ),
             @ApiResponse(
                 responseCode = "401",
-                description = "유효하지 않은 리프레시 토큰",
+                description = "유효하지 않거나 만료된 리프레시 토큰",
+                content = @Content(
+                    schema = @Schema(implementation = ErrorResponse.class)
+                )
+            ),
+            @ApiResponse(
+                responseCode = "404",
+                description = "사용자를 찾을 수 없습니다",
                 content = @Content(
                     schema = @Schema(implementation = ErrorResponse.class)
                 )
@@ -146,7 +176,7 @@ public interface SwaggerAuthController {
         }
     )
     ResponseEntity<TokenResponse> registerUserInfo(
-        RegisterUserProfileRequest request,
+        @Valid @RequestBody RegisterUserProfileRequest request,
         HttpServletRequest httpRequest
     );
 

--- a/backend/src/main/java/com/healthy_plate/auth/presentation/SwaggerAuthController.java
+++ b/backend/src/main/java/com/healthy_plate/auth/presentation/SwaggerAuthController.java
@@ -1,7 +1,7 @@
 package com.healthy_plate.auth.presentation;
 
-import com.healthy_plate.auth.presentation.dto.TokenResponse;
 import com.healthy_plate.auth.presentation.dto.RegisterUserProfileRequest;
+import com.healthy_plate.auth.presentation.dto.TokenResponse;
 import com.healthy_plate.shared.error.ErrorResponse;
 import com.healthy_plate.shared.s3.PresignedUrlRequest;
 import com.healthy_plate.shared.s3.PresignedUrlResponse;
@@ -62,6 +62,50 @@ public interface SwaggerAuthController {
             )
         }
     )
+    ResponseEntity<TokenResponse> onBoardingAccessToken(HttpServletRequest request);
+
+    @Operation(
+        summary = "액세스 토큰 갱신",
+        tags = "인증",
+        description = "리프레시 토큰을 사용하여 새로운 액세스 토큰을 발급합니다.",
+        responses = {
+            @ApiResponse(
+                responseCode = "200",
+                description = "토큰 갱신 성공",
+                content = @Content(
+                    schema = @Schema(implementation = TokenResponse.class)
+                )
+            ),
+            @ApiResponse(
+                responseCode = "400",
+                description = "잘못된 요청 (refresh_token 쿠키 없음)",
+                content = @Content(
+                    schema = @Schema(implementation = ErrorResponse.class)
+                )
+            ),
+            @ApiResponse(
+                responseCode = "401",
+                description = "유효하지 않거나 만료된 리프레시 토큰",
+                content = @Content(
+                    schema = @Schema(implementation = ErrorResponse.class)
+                )
+            ),
+            @ApiResponse(
+                responseCode = "403",
+                description = "프로필 등록이 필요합니다",
+                content = @Content(
+                    schema = @Schema(implementation = ErrorResponse.class)
+                )
+            ),
+            @ApiResponse(
+                responseCode = "404",
+                description = "사용자를 찾을 수 없습니다",
+                content = @Content(
+                    schema = @Schema(implementation = ErrorResponse.class)
+                )
+            )
+        }
+    )
     ResponseEntity<TokenResponse> getAccessToken(HttpServletRequest request);
 
     @Operation(
@@ -69,27 +113,27 @@ public interface SwaggerAuthController {
         tags = "인증",
         description = """
             회원가입 시 프로필 이미지를 업로드하기 위한 Presigned URL을 생성합니다.
-
+            
             **요청 형식:**
             - Content-Type: application/json
             - Body: { "contentType": "image/jpeg", "fileSize": 2097152 }
-
+            
             **지원하는 이미지 형식:**
             - JPEG (image/jpeg)
             - PNG (image/png)
             - WEBP (image/webp)
-
+            
             **파일 크기 제한:**
             - 최대 5MB (5,242,880 bytes)
             - 프론트엔드와 백엔드 모두에서 검증
-
+            
             **사용 순서:**
             1. 프론트엔드에서 파일 선택 시 file.type과 file.size 가져오기
             2. 프론트엔드에서 파일 크기 체크 (5MB 이하인지 확인)
             3. 이 API를 JSON으로 호출하여 presignedUrl과 fileUrl을 받습니다
             4. presignedUrl로 이미지를 S3에 직접 PUT 업로드합니다
             5. PATCH /api/auth/register 호출 시 fileUrl을 profileImageUrl에 포함합니다
-
+            
             **인증:** refresh_token 쿠키 사용 (회원가입 전이므로 accessToken 없음)
             """,
         responses = {
@@ -124,8 +168,8 @@ public interface SwaggerAuthController {
         }
     )
     ResponseEntity<PresignedUrlResponse> getPresignedUrl(
-            @Valid @RequestBody PresignedUrlRequest request,
-            HttpServletRequest httpRequest
+        @Valid @RequestBody PresignedUrlRequest request,
+        HttpServletRequest httpRequest
     );
 
     @Operation(
@@ -133,15 +177,15 @@ public interface SwaggerAuthController {
         tags = "인증",
         description = """
             OAuth2 로그인 후 사용자의 프로필을 등록하고 액세스 토큰을 반환합니다.
-
+            
             **이미지 업로드 방법:**
             1. POST /api/auth/profile-image/presigned-url로 업로드 URL 받기
             2. 받은 presignedUrl로 이미지를 S3에 직접 PUT 업로드
             3. 이 API 호출 시 fileUrl을 profileImageUrl에 포함
-
+            
             **필수:** nickname (2-50자)
             **선택:** profileImageUrl (S3 URL), introduction (최대 500자)
-
+            
             **인증:** refresh_token 쿠키 사용
             """,
         responses = {

--- a/backend/src/main/java/com/healthy_plate/auth/presentation/SwaggerAuthController.java
+++ b/backend/src/main/java/com/healthy_plate/auth/presentation/SwaggerAuthController.java
@@ -5,7 +5,6 @@ import com.healthy_plate.auth.presentation.dto.TokenResponse;
 import com.healthy_plate.shared.error.ErrorResponse;
 import com.healthy_plate.shared.s3.PresignedUrlRequest;
 import com.healthy_plate.shared.s3.PresignedUrlResponse;
-import com.healthy_plate.user.domain.model.User;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -44,13 +43,6 @@ public interface SwaggerAuthController {
             @ApiResponse(
                 responseCode = "401",
                 description = "유효하지 않거나 만료된 리프레시 토큰",
-                content = @Content(
-                    schema = @Schema(implementation = ErrorResponse.class)
-                )
-            ),
-            @ApiResponse(
-                responseCode = "403",
-                description = "프로필 등록이 필요합니다",
                 content = @Content(
                     schema = @Schema(implementation = ErrorResponse.class)
                 )

--- a/backend/src/main/java/com/healthy_plate/auth/presentation/SwaggerAuthController.java
+++ b/backend/src/main/java/com/healthy_plate/auth/presentation/SwaggerAuthController.java
@@ -224,7 +224,7 @@ public interface SwaggerAuthController {
     )
     ResponseEntity<Void> registerUserInfo(
         @Valid @RequestBody RegisterUserProfileRequest request,
-        @AuthenticationPrincipal User user
+        @AuthenticationPrincipal Long userId
     );
 
     @Operation(

--- a/backend/src/main/java/com/healthy_plate/auth/presentation/SwaggerAuthController.java
+++ b/backend/src/main/java/com/healthy_plate/auth/presentation/SwaggerAuthController.java
@@ -5,6 +5,7 @@ import com.healthy_plate.auth.presentation.dto.TokenResponse;
 import com.healthy_plate.shared.error.ErrorResponse;
 import com.healthy_plate.shared.s3.PresignedUrlRequest;
 import com.healthy_plate.shared.s3.PresignedUrlResponse;
+import com.healthy_plate.user.domain.model.User;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -14,6 +15,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.RequestBody;
 
@@ -186,7 +188,8 @@ public interface SwaggerAuthController {
             **필수:** nickname (2-50자)
             **선택:** profileImageUrl (S3 URL), introduction (최대 500자)
             
-            **인증:** refresh_token 쿠키 사용
+            **인증:** Access Token (Authorization: Bearer {token})
+            **참고:** OAuth2 로그인 직후 프로필 등록 시에는 /api/auth/onboarding으로 Access Token 발급 필요
             """,
         responses = {
             @ApiResponse(
@@ -198,14 +201,14 @@ public interface SwaggerAuthController {
             ),
             @ApiResponse(
                 responseCode = "400",
-                description = "잘못된 요청 (refresh_token 쿠키 없음, 유효성 검증 실패)",
+                description = "잘못된 요청 (유효성 검증 실패)",
                 content = @Content(
                     schema = @Schema(implementation = ErrorResponse.class)
                 )
             ),
             @ApiResponse(
                 responseCode = "401",
-                description = "유효하지 않거나 만료된 리프레시 토큰",
+                description = "유효하지 않거나 만료된 액세스 토큰",
                 content = @Content(
                     schema = @Schema(implementation = ErrorResponse.class)
                 )
@@ -219,9 +222,9 @@ public interface SwaggerAuthController {
             )
         }
     )
-    ResponseEntity<TokenResponse> registerUserInfo(
+    ResponseEntity<Void> registerUserInfo(
         @Valid @RequestBody RegisterUserProfileRequest request,
-        HttpServletRequest httpRequest
+        @AuthenticationPrincipal User user
     );
 
     @Operation(

--- a/backend/src/main/java/com/healthy_plate/ingredient/presentation/IngredientController.java
+++ b/backend/src/main/java/com/healthy_plate/ingredient/presentation/IngredientController.java
@@ -22,7 +22,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/ingredients")
 @RequiredArgsConstructor
-public class IngredientController {
+public class IngredientController implements SwaggerIngredientController {
 
     private final IngredientService ingredientService;
 

--- a/backend/src/main/java/com/healthy_plate/ingredient/presentation/SwaggerIngredientController.java
+++ b/backend/src/main/java/com/healthy_plate/ingredient/presentation/SwaggerIngredientController.java
@@ -5,6 +5,7 @@ import com.healthy_plate.ingredient.presentation.dto.IngredientResponse;
 import com.healthy_plate.ingredient.presentation.dto.IngredientUpdateRequest;
 import com.healthy_plate.shared.error.ErrorResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -24,13 +25,13 @@ public interface SwaggerIngredientController {
         tags = "식재료",
         description = """
             새로운 식재료를 생성합니다.
-
+            
             **필수 필드:**
             - name: 식재료명 (최대 100자)
             - servingSize: 제공량
             - unit: 단위
             - calorie: 칼로리
-
+            
             **선택 필드:**
             - nameEn: 영문 식재료명 (최대 100자)
             """,
@@ -62,11 +63,11 @@ public interface SwaggerIngredientController {
         tags = "식재료",
         description = """
             식재료를 이름으로 검색합니다.
-
+            
             **검색 방식:**
             - name 파라미터가 없으면 전체 식재료 목록을 반환합니다.
             - name 파라미터가 있으면 해당 이름을 포함하는 식재료를 검색합니다.
-
+            
             **응답 필드:**
             - name: 식재료명
             - calorie: 칼로리
@@ -76,7 +77,7 @@ public interface SwaggerIngredientController {
                 responseCode = "200",
                 description = "검색 성공",
                 content = @Content(
-                    schema = @Schema(implementation = IngredientResponse.class)
+                    array = @ArraySchema(schema = @Schema(implementation = IngredientResponse.class))
                 )
             )
         }
@@ -88,14 +89,14 @@ public interface SwaggerIngredientController {
         tags = "식재료",
         description = """
             기존 식재료 정보를 수정합니다.
-
+            
             **수정 가능한 필드:**
             - name: 식재료명 (최대 100자)
             - nameEn: 영문 식재료명 (최대 100자)
             - servingSize: 제공량
             - unit: 단위
             - calorie: 칼로리
-
+            
             **참고:** 모든 필드는 선택적이며, 제공된 필드만 수정됩니다.
             """,
         responses = {

--- a/backend/src/main/java/com/healthy_plate/ingredient/presentation/SwaggerIngredientController.java
+++ b/backend/src/main/java/com/healthy_plate/ingredient/presentation/SwaggerIngredientController.java
@@ -1,0 +1,146 @@
+package com.healthy_plate.ingredient.presentation;
+
+import com.healthy_plate.ingredient.presentation.dto.IngredientRequest;
+import com.healthy_plate.ingredient.presentation.dto.IngredientResponse;
+import com.healthy_plate.ingredient.presentation.dto.IngredientUpdateRequest;
+import com.healthy_plate.shared.error.ErrorResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import java.util.List;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Tag(name = "식재료", description = "식재료 관련 API")
+public interface SwaggerIngredientController {
+
+    @Operation(
+        summary = "식재료 생성",
+        tags = "식재료",
+        description = """
+            새로운 식재료를 생성합니다.
+
+            **필수 필드:**
+            - name: 식재료명 (최대 100자)
+            - servingSize: 제공량
+            - unit: 단위
+            - calorie: 칼로리
+
+            **선택 필드:**
+            - nameEn: 영문 식재료명 (최대 100자)
+            """,
+        responses = {
+            @ApiResponse(
+                responseCode = "200",
+                description = "식재료 생성 성공"
+            ),
+            @ApiResponse(
+                responseCode = "400",
+                description = "잘못된 요청 (유효성 검증 실패)",
+                content = @Content(
+                    schema = @Schema(implementation = ErrorResponse.class)
+                )
+            ),
+            @ApiResponse(
+                responseCode = "409",
+                description = "이미 존재하는 식재료명",
+                content = @Content(
+                    schema = @Schema(implementation = ErrorResponse.class)
+                )
+            )
+        }
+    )
+    ResponseEntity<Void> create(@Valid @RequestBody IngredientRequest request);
+
+    @Operation(
+        summary = "식재료 검색",
+        tags = "식재료",
+        description = """
+            식재료를 이름으로 검색합니다.
+
+            **검색 방식:**
+            - name 파라미터가 없으면 전체 식재료 목록을 반환합니다.
+            - name 파라미터가 있으면 해당 이름을 포함하는 식재료를 검색합니다.
+
+            **응답 필드:**
+            - name: 식재료명
+            - calorie: 칼로리
+            """,
+        responses = {
+            @ApiResponse(
+                responseCode = "200",
+                description = "검색 성공",
+                content = @Content(
+                    schema = @Schema(implementation = IngredientResponse.class)
+                )
+            )
+        }
+    )
+    ResponseEntity<List<IngredientResponse>> search(@RequestParam(required = false) String name);
+
+    @Operation(
+        summary = "식재료 수정",
+        tags = "식재료",
+        description = """
+            기존 식재료 정보를 수정합니다.
+
+            **수정 가능한 필드:**
+            - name: 식재료명 (최대 100자)
+            - nameEn: 영문 식재료명 (최대 100자)
+            - servingSize: 제공량
+            - unit: 단위
+            - calorie: 칼로리
+
+            **참고:** 모든 필드는 선택적이며, 제공된 필드만 수정됩니다.
+            """,
+        responses = {
+            @ApiResponse(
+                responseCode = "204",
+                description = "식재료 수정 성공"
+            ),
+            @ApiResponse(
+                responseCode = "400",
+                description = "잘못된 요청 (유효성 검증 실패)",
+                content = @Content(
+                    schema = @Schema(implementation = ErrorResponse.class)
+                )
+            ),
+            @ApiResponse(
+                responseCode = "404",
+                description = "존재하지 않는 식재료",
+                content = @Content(
+                    schema = @Schema(implementation = ErrorResponse.class)
+                )
+            )
+        }
+    )
+    ResponseEntity<Void> update(
+        @PathVariable("id") Long id,
+        @Valid @RequestBody IngredientUpdateRequest request
+    );
+
+    @Operation(
+        summary = "식재료 삭제",
+        tags = "식재료",
+        description = "식재료를 삭제합니다.",
+        responses = {
+            @ApiResponse(
+                responseCode = "204",
+                description = "식재료 삭제 성공"
+            ),
+            @ApiResponse(
+                responseCode = "404",
+                description = "존재하지 않는 식재료",
+                content = @Content(
+                    schema = @Schema(implementation = ErrorResponse.class)
+                )
+            )
+        }
+    )
+    ResponseEntity<Void> delete(@PathVariable("id") Long id);
+}

--- a/backend/src/main/java/com/healthy_plate/shared/error/ErrorResponse.java
+++ b/backend/src/main/java/com/healthy_plate/shared/error/ErrorResponse.java
@@ -9,22 +9,22 @@ import lombok.Getter;
 @Getter
 public class ErrorResponse {
 
-    @Schema(description = "HTTP 상태 코드", example = "401")
+    @Schema(description = "HTTP 상태 코드")
     private final int status;
 
-    @Schema(description = "오류 코드 (A1xx: 인증/인가, B1xx: 비즈니스)", example = "A108")
+    @Schema(description = "오류 코드 (A1xx: 인증/인가, B1xx: 비즈니스")
     private final String code;
 
-    @Schema(description = "오류 메시지", example = "유효하지 않은 Access Token 입니다.")
+    @Schema(description = "오류 메시지")
     private final String message;
 
-    @Schema(description = "요청 HTTP 메서드", example = "GET")
+    @Schema(description = "요청 HTTP 메서드")
     private final String method;
 
-    @Schema(description = "요청 경로", example = "/api/users")
+    @Schema(description = "요청 경로")
     private final String path;
 
-    @Schema(description = "오류 발생 시간", example = "2023-10-01T12:00:00")
+    @Schema(description = "오류 발생 시간")
     private final LocalDateTime timestamp;
 
     public ErrorResponse(int status, String code, String message, String method, String path) {

--- a/backend/src/main/java/com/healthy_plate/shared/error/ErrorResponse.java
+++ b/backend/src/main/java/com/healthy_plate/shared/error/ErrorResponse.java
@@ -12,7 +12,7 @@ public class ErrorResponse {
     @Schema(description = "HTTP 상태 코드")
     private final int status;
 
-    @Schema(description = "오류 코드 (A1xx: 인증/인가, B1xx: 비즈니스")
+    @Schema(description = "오류 코드 (A1xx: 인증/인가, B1xx: 비즈니스)")
     private final String code;
 
     @Schema(description = "오류 메시지")

--- a/backend/src/main/java/com/healthy_plate/user/presentation/SwaggerUserController.java
+++ b/backend/src/main/java/com/healthy_plate/user/presentation/SwaggerUserController.java
@@ -11,9 +11,11 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 
 @Tag(name = "사용자", description = "사용자 관련 API")
 public interface SwaggerUserController {
@@ -117,7 +119,7 @@ public interface SwaggerUserController {
     )
     ResponseEntity<PresignedUrlResponse> getPresignedUrl(
         @AuthenticationPrincipal Long userId,
-        PresignedUrlRequest request
+        @Valid @RequestBody PresignedUrlRequest request
     );
 
     @Operation(
@@ -166,6 +168,6 @@ public interface SwaggerUserController {
     )
     ResponseEntity<UserResponse> updateProfile(
         @AuthenticationPrincipal Long userId,
-        UpdateProfileRequest request
+        @Valid @RequestBody UpdateProfileRequest request
     );
 }


### PR DESCRIPTION
### 🧪 작업 브랜치
> be/ingredient recipe domain -setting

<br/>

---
### 🔗 연결된 이슈 번호
<!--이 PR이 머지될 때 자동으로 닫힐 이슈들을 기재합니다.
자동 닫힘 키워드를 사용해주세요: **`#이슈번호`** -->
<br/>

### 🛠 상세 작업 내용
---
<!--작업 내용을 구체적인 목록 형태로 기술합니다.-->
- [ ] 작업 내용 1:  기존 refresh 토큰을 사용하여 회원등록하는 로직은 access토큰으로 대체
- [ ] 작업 내용 1: 회원가입전 access 토큰을 발급받을 수 있도록 api를 추가함

<br/>

### 📷 스크린샷 (선택사항)
---
<!-- UI 변경이나 특정 동작이 필요한 경우 스크린샷이나 GIF를 첨부합니다.-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 온보딩 프로세스를 위한 새로운 인증 엔드포인트 추가
  * 성분 관련 API에 새로운 인터페이스 기반 구조 추가

* **Bug Fixes**
  * JWT 토큰 처리에서 누락된 역할 정보에 대한 null-safe 처리 개선

* **Refactor**
  * 사용자 프로필 등록 프로세스 간소화
  * 토큰 저장 및 관리 로직 최적화
  * API 요청 검증 강화

* **Documentation**
  * 인증 및 성분 API 엔드포인트 문서화 개선

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->